### PR TITLE
fix: add Mega Evolution data for Legends ZA (64 megas)

### DIFF
--- a/pokedex/LegendsZA/LegendsZA.json
+++ b/pokedex/LegendsZA/LegendsZA.json
@@ -75,21 +75,25 @@
           "id": "0154_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガメガニウム",
           "gigantamax": null,
           "type1": "くさ",
-          "type2": "",
+          "type2": "フェアリー",
           "hp": 80,
-          "attack": 82,
-          "defense": 100,
-          "special_attack": 83,
-          "special_defense": 100,
+          "attack": 92,
+          "defense": 115,
+          "special_attack": 143,
+          "special_defense": 115,
           "speed": 80,
           "ability1": "",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>花<rp>(</rp><rt>はな</rt><rp>)</rp></ruby>びらから <ruby>発散<rp>(</rp><rt>はっさん</rt><rp>)</rp></ruby>される においには <ruby>争<rp>(</rp><rt>あらそ</rt><rp>)</rp></ruby>う <ruby>気持<rp>(</rp><rt>きも</rt><rp>)</rp></ruby>ちを <ruby>静<rp>(</rp><rt>しず</rt><rp>)</rp></ruby>める <ruby>成分<rp>(</rp><rt>せいぶん</rt><rp>)</rp></ruby>が <ruby>含<rp>(</rp><rt>ふく</rt><rp>)</rp></ruby>まれる。"
+          },
+          "name": {
+            "jpn": "メガメガニウム",
+            "eng": "Mega Meganium"
           }
         }
       },
@@ -165,21 +169,25 @@
           "id": "0500_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガエンブオー",
           "gigantamax": null,
           "type1": "ほのお",
           "type2": "かくとう",
           "hp": 110,
-          "attack": 123,
-          "defense": 65,
-          "special_attack": 100,
-          "special_defense": 65,
-          "speed": 65,
+          "attack": 148,
+          "defense": 75,
+          "special_attack": 110,
+          "special_defense": 110,
+          "speed": 75,
           "ability1": "",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>炎<rp>(</rp><rt>ほのお</rt><rp>)</rp></ruby>の あごひげを たくわえる。パワーと スピードを <ruby>兼<rp>(</rp><rt>か</rt><rp>)</rp></ruby>ね<ruby>備<rp>(</rp><rt>そな</rt><rp>)</rp></ruby>えた <ruby>格闘<rp>(</rp><rt>かくとう</rt><rp>)</rp></ruby>の <ruby>技<rp>(</rp><rt>わざ</rt><rp>)</rp></ruby>を <ruby>身<rp>(</rp><rt>み</rt><rp>)</rp></ruby>につけている。"
+          },
+          "name": {
+            "jpn": "メガエンブオー",
+            "eng": "Mega Emboar"
           }
         }
       },
@@ -255,21 +263,25 @@
           "id": "0160_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガオーダイル",
           "gigantamax": null,
           "type1": "みず",
-          "type2": "",
+          "type2": "ドラゴン",
           "hp": 85,
-          "attack": 105,
-          "defense": 100,
-          "special_attack": 79,
-          "special_defense": 83,
+          "attack": 160,
+          "defense": 125,
+          "special_attack": 89,
+          "special_defense": 93,
           "speed": 78,
           "ability1": "",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>普段<rp>(</rp><rt>ふだん</rt><rp>)</rp></ruby>は ゆっくりとした <ruby>動<rp>(</rp><rt>うご</rt><rp>)</rp></ruby>きだが <ruby>獲物<rp>(</rp><rt>えもの</rt><rp>)</rp></ruby>に <ruby>噛<rp>(</rp><rt>か</rt><rp>)</rp></ruby>みつくときは <ruby>目<rp>(</rp><rt>め</rt><rp>)</rp></ruby>にも とまらない スピードだ。"
+          },
+          "name": {
+            "jpn": "メガオーダイル",
+            "eng": "Mega Feraligatr"
           }
         }
       },
@@ -529,21 +541,25 @@
           "id": "0015_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガスピアー",
           "gigantamax": null,
-          "type1": "どく",
-          "type2": "むし",
+          "type1": "むし",
+          "type2": "どく",
           "hp": 65,
-          "attack": 90,
+          "attack": 150,
           "defense": 40,
-          "special_attack": 45,
+          "special_attack": 15,
           "special_defense": 80,
-          "speed": 75,
-          "ability1": "",
+          "speed": 145,
+          "ability1": "てきおうりょく",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>集団<rp>(</rp><rt>しゅうだん</rt><rp>)</rp></ruby>で <ruby>現<rp>(</rp><rt>あらわ</rt><rp>)</rp></ruby>れることもある。<ruby>猛<rp>(</rp><rt>もう</rt><rp>)</rp></ruby>スピードで <ruby>飛<rp>(</rp><rt>と</rt><rp>)</rp></ruby>びまわり お<ruby>尻<rp>(</rp><rt>しり</rt><rp>)</rp></ruby>の <ruby>毒針<rp>(</rp><rt>どくばり</rt><rp>)</rp></ruby>で <ruby>刺<rp>(</rp><rt>さ</rt><rp>)</rp></ruby>しまくる。"
+          },
+          "name": {
+            "jpn": "メガスピアー",
+            "eng": "Mega Beedrill"
           }
         }
       },
@@ -619,21 +635,25 @@
           "id": "0018_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガピジョット",
           "gigantamax": null,
           "type1": "ノーマル",
           "type2": "ひこう",
           "hp": 83,
           "attack": 80,
-          "defense": 75,
-          "special_attack": 70,
-          "special_defense": 70,
-          "speed": 101,
-          "ability1": "",
+          "defense": 80,
+          "special_attack": 135,
+          "special_defense": 80,
+          "speed": 121,
+          "ability1": "ノーガード",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "エサを <ruby>探<rp>(</rp><rt>さが</rt><rp>)</rp></ruby>すとき <ruby>水面<rp>(</rp><rt>すいめん</rt><rp>)</rp></ruby> すれすれを <ruby>滑<rp>(</rp><rt>すべ</rt><rp>)</rp></ruby>るように <ruby>飛<rp>(</rp><rt>と</rt><rp>)</rp></ruby>んで コイキングなどを わしづかみにする。"
+          },
+          "name": {
+            "jpn": "メガピジョット",
+            "eng": "Mega Pidgeot"
           }
         }
       },
@@ -709,21 +729,25 @@
           "id": "0181_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガデンリュウ",
           "gigantamax": null,
           "type1": "でんき",
-          "type2": "",
+          "type2": "ドラゴン",
           "hp": 90,
-          "attack": 75,
-          "defense": 85,
-          "special_attack": 115,
-          "special_defense": 90,
-          "speed": 55,
-          "ability1": "",
+          "attack": 95,
+          "defense": 105,
+          "special_attack": 165,
+          "special_defense": 110,
+          "speed": 45,
+          "ability1": "かたやぶり",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>尻尾<rp>(</rp><rt>しっぽ</rt><rp>)</rp></ruby>の <ruby>先<rp>(</rp><rt>さき</rt><rp>)</rp></ruby>が <ruby>光<rp>(</rp><rt>ひか</rt><rp>)</rp></ruby>り<ruby>輝<rp>(</rp><rt>かがや</rt><rp>)</rp></ruby>く。<ruby>光<rp>(</rp><rt>ひかり</rt><rp>)</rp></ruby>は はるか <ruby>遠<rp>(</rp><rt>とお</rt><rp>)</rp></ruby>くまで <ruby>届<rp>(</rp><rt>とど</rt><rp>)</rp></ruby>き <ruby>迷<rp>(</rp><rt>まよ</rt><rp>)</rp></ruby>った<ruby>者<rp>(</rp><rt>もの</rt><rp>)</rp></ruby>の <ruby>道標<rp>(</rp><rt>みちしるべ</rt><rp>)</rp></ruby>となる。"
+          },
+          "name": {
+            "jpn": "メガデンリュウ",
+            "eng": "Mega Ampharos"
           }
         }
       },
@@ -891,21 +915,25 @@
           "id": "0130_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガギャラドス",
           "gigantamax": null,
           "type1": "みず",
-          "type2": "ひこう",
+          "type2": "あく",
           "hp": 95,
-          "attack": 125,
-          "defense": 79,
-          "special_attack": 60,
-          "special_defense": 100,
+          "attack": 155,
+          "defense": 109,
+          "special_attack": 70,
+          "special_defense": 130,
           "speed": 81,
-          "ability1": "",
+          "ability1": "かたやぶり",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>争<rp>(</rp><rt>あらそ</rt><rp>)</rp></ruby>いの <ruby>起<rp>(</rp><rt>お</rt><rp>)</rp></ruby>こった <ruby>村<rp>(</rp><rt>むら</rt><rp>)</rp></ruby>を <ruby>焼<rp>(</rp><rt>や</rt><rp>)</rp></ruby>きつくしたという <ruby>記録<rp>(</rp><rt>きろく</rt><rp>)</rp></ruby>が <ruby>古文書<rp>(</rp><rt>こもんじょ</rt><rp>)</rp></ruby>に <ruby>残<rp>(</rp><rt>のこ</rt><rp>)</rp></ruby>されている。"
+          },
+          "name": {
+            "jpn": "メガギャラドス",
+            "eng": "Mega Gyarados"
           }
         }
       },
@@ -958,21 +986,25 @@
           "id": "0689_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガガメノデス",
           "gigantamax": null,
-          "type1": "みず",
-          "type2": "いわ",
+          "type1": "いわ",
+          "type2": "かくとう",
           "hp": 72,
-          "attack": 105,
-          "defense": 115,
-          "special_attack": 54,
-          "special_defense": 86,
-          "speed": 68,
+          "attack": 140,
+          "defense": 130,
+          "special_attack": 64,
+          "special_defense": 106,
+          "speed": 88,
           "ability1": "",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>手足<rp>(</rp><rt>てあし</rt><rp>)</rp></ruby>にも <ruby>脳<rp>(</rp><rt>のう</rt><rp>)</rp></ruby>が あり <ruby>勝手<rp>(</rp><rt>かって</rt><rp>)</rp></ruby>に <ruby>動<rp>(</rp><rt>うご</rt><rp>)</rp></ruby>けるが <ruby>普段<rp>(</rp><rt>ふだん</rt><rp>)</rp></ruby>は <ruby>頭<rp>(</rp><rt>あたま</rt><rp>)</rp></ruby>の ガメノデスの <ruby>命令<rp>(</rp><rt>めいれい</rt><rp>)</rp></ruby>に <ruby>従<rp>(</rp><rt>したが</rt><rp>)</rp></ruby>う。"
+          },
+          "name": {
+            "jpn": "メガガメノデス",
+            "eng": "Mega Barbaracle"
           }
         }
       },
@@ -1025,21 +1057,25 @@
           "id": "0121_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガスターミー",
           "gigantamax": null,
           "type1": "みず",
           "type2": "エスパー",
           "hp": 60,
-          "attack": 75,
-          "defense": 85,
-          "special_attack": 100,
-          "special_defense": 85,
-          "speed": 115,
+          "attack": 140,
+          "defense": 105,
+          "special_attack": 130,
+          "special_defense": 105,
+          "speed": 120,
           "ability1": "",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>体<rp>(</rp><rt>からだ</rt><rp>)</rp></ruby>の <ruby>中心<rp>(</rp><rt>ちゅうしん</rt><rp>)</rp></ruby>にある <ruby>赤<rp>(</rp><rt>あか</rt><rp>)</rp></ruby>いコアから <ruby>夜空<rp>(</rp><rt>よぞら</rt><rp>)</rp></ruby>に <ruby>向<rp>(</rp><rt>む</rt><rp>)</rp></ruby>かって <ruby>謎<rp>(</rp><rt>なぞ</rt><rp>)</rp></ruby>の <ruby>電波<rp>(</rp><rt>でんぱ</rt><rp>)</rp></ruby>を <ruby>発信<rp>(</rp><rt>はっしん</rt><rp>)</rp></ruby>している。"
+          },
+          "name": {
+            "jpn": "メガスターミー",
+            "eng": "Mega Starmie"
           }
         }
       },
@@ -1547,21 +1583,25 @@
           "id": "0668_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガカエンジシ",
           "gigantamax": null,
-          "type1": "ノーマル",
-          "type2": "ほのお",
+          "type1": "ほのお",
+          "type2": "ノーマル",
           "hp": 86,
-          "attack": 68,
-          "defense": 72,
-          "special_attack": 109,
-          "special_defense": 66,
-          "speed": 106,
+          "attack": 88,
+          "defense": 92,
+          "special_attack": 129,
+          "special_defense": 86,
+          "speed": 126,
           "ability1": "",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>群<rp>(</rp><rt>む</rt><rp>)</rp></ruby>れの <ruby>中<rp>(</rp><rt>なか</rt><rp>)</rp></ruby>で <ruby>一番<rp>(</rp><rt>いちばん</rt><rp>)</rp></ruby> <ruby>大<rp>(</rp><rt>おお</rt><rp>)</rp></ruby>きな <ruby>炎<rp>(</rp><rt>ほのお</rt><rp>)</rp></ruby>の たてがみを <ruby>持<rp>(</rp><rt>も</rt><rp>)</rp></ruby>つ オスが リーダーとして <ruby>仲間<rp>(</rp><rt>なかま</rt><rp>)</rp></ruby>を <ruby>率<rp>(</rp><rt>ひき</rt><rp>)</rp></ruby>いる。"
+          },
+          "name": {
+            "jpn": "メガカエンジシ",
+            "eng": "Mega Pyroar"
           }
         }
       },
@@ -1842,21 +1882,25 @@
           "id": "0036_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガピクシー",
           "gigantamax": null,
           "type1": "フェアリー",
-          "type2": "",
+          "type2": "ひこう",
           "hp": 95,
-          "attack": 70,
-          "defense": 73,
-          "special_attack": 95,
-          "special_defense": 90,
-          "speed": 60,
+          "attack": 80,
+          "defense": 93,
+          "special_attack": 135,
+          "special_defense": 110,
+          "speed": 70,
           "ability1": "",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>妖精<rp>(</rp><rt>ようせい</rt><rp>)</rp></ruby>の <ruby>仲間<rp>(</rp><rt>なかま</rt><rp>)</rp></ruby>で めったに <ruby>人前<rp>(</rp><rt>ひとまえ</rt><rp>)</rp></ruby>に <ruby>出<rp>(</rp><rt>で</rt><rp>)</rp></ruby>てこない。<ruby>気配<rp>(</rp><rt>けはい</rt><rp>)</rp></ruby>を <ruby>感<rp>(</rp><rt>かん</rt><rp>)</rp></ruby>じて すぐに <ruby>逃<rp>(</rp><rt>に</rt><rp>)</rp></ruby>げてしまうようだ。"
+          },
+          "name": {
+            "jpn": "メガピクシー",
+            "eng": "Mega Clefable"
           }
         }
       },
@@ -2024,21 +2068,25 @@
           "id": "0065_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガフーディン",
           "gigantamax": null,
           "type1": "エスパー",
           "type2": "",
           "hp": 55,
           "attack": 50,
-          "defense": 45,
-          "special_attack": 135,
-          "special_defense": 95,
-          "speed": 120,
-          "ability1": "",
+          "defense": 65,
+          "special_attack": 175,
+          "special_defense": 105,
+          "speed": 150,
+          "ability1": "トレース",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>脳細胞<rp>(</rp><rt>のうさいぼう</rt><rp>)</rp></ruby>は いつも <ruby>分裂<rp>(</rp><rt>ぶんれつ</rt><rp>)</rp></ruby>して <ruby>死<rp>(</rp><rt>し</rt><rp>)</rp></ruby>ぬまで <ruby>増<rp>(</rp><rt>ふ</rt><rp>)</rp></ruby>え<ruby>続<rp>(</rp><rt>つづ</rt><rp>)</rp></ruby>けるので あらゆることを <ruby>覚<rp>(</rp><rt>おぼ</rt><rp>)</rp></ruby>えておける。"
+          },
+          "name": {
+            "jpn": "メガフーディン",
+            "eng": "Mega Alakazam"
           }
         }
       },
@@ -2114,21 +2162,25 @@
           "id": "0094_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガゲンガー",
           "gigantamax": null,
-          "type1": "どく",
-          "type2": "ゴースト",
+          "type1": "ゴースト",
+          "type2": "どく",
           "hp": 60,
           "attack": 65,
-          "defense": 60,
-          "special_attack": 130,
-          "special_defense": 75,
-          "speed": 110,
-          "ability1": "",
+          "defense": 80,
+          "special_attack": 170,
+          "special_defense": 95,
+          "speed": 130,
+          "ability1": "かげふみ",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>物陰<rp>(</rp><rt>ものかげ</rt><rp>)</rp></ruby>に <ruby>姿<rp>(</rp><rt>すがた</rt><rp>)</rp></ruby>を <ruby>隠<rp>(</rp><rt>かく</rt><rp>)</rp></ruby>す。ゲンガーの <ruby>潜<rp>(</rp><rt>ひそ</rt><rp>)</rp></ruby>んでいる <ruby>部屋<rp>(</rp><rt>へや</rt><rp>)</rp></ruby>は <ruby>温度<rp>(</rp><rt>おんど</rt><rp>)</rp></ruby>が ５<ruby>度<rp>(</rp><rt>ど</rt><rp>)</rp></ruby> <ruby>下<rp>(</rp><rt>さ</rt><rp>)</rp></ruby>がると いわれる。"
+          },
+          "name": {
+            "jpn": "メガゲンガー",
+            "eng": "Mega Gengar"
           }
         }
       },
@@ -2204,21 +2256,25 @@
           "id": "0545_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガペンドラー",
           "gigantamax": null,
-          "type1": "どく",
-          "type2": "むし",
+          "type1": "むし",
+          "type2": "どく",
           "hp": 60,
-          "attack": 100,
-          "defense": 89,
-          "special_attack": 55,
-          "special_defense": 69,
-          "speed": 112,
+          "attack": 140,
+          "defense": 149,
+          "special_attack": 75,
+          "special_defense": 99,
+          "speed": 62,
           "ability1": "",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>獲物<rp>(</rp><rt>えもの</rt><rp>)</rp></ruby>を <ruby>首<rp>(</rp><rt>くび</rt><rp>)</rp></ruby>のツメで <ruby>挟<rp>(</rp><rt>はさ</rt><rp>)</rp></ruby>みこみ <ruby>身動<rp>(</rp><rt>みうご</rt><rp>)</rp></ruby>きを とれなくしてから <ruby>猛毒<rp>(</rp><rt>もうどく</rt><rp>)</rp></ruby>を <ruby>与<rp>(</rp><rt>あた</rt><rp>)</rp></ruby>え とどめを <ruby>刺<rp>(</rp><rt>さ</rt><rp>)</rp></ruby>す。"
+          },
+          "name": {
+            "jpn": "メガペンドラー",
+            "eng": "Mega Scolipede"
           }
         }
       },
@@ -2384,21 +2440,25 @@
           "id": "0071_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガウツボット",
           "gigantamax": null,
           "type1": "くさ",
           "type2": "どく",
           "hp": 80,
-          "attack": 105,
-          "defense": 65,
-          "special_attack": 100,
-          "special_defense": 70,
+          "attack": 125,
+          "defense": 85,
+          "special_attack": 135,
+          "special_defense": 95,
           "speed": 70,
           "ability1": "",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>体内<rp>(</rp><rt>たいない</rt><rp>)</rp></ruby>に <ruby>取<rp>(</rp><rt>と</rt><rp>)</rp></ruby>りこまれた ものは どんなに <ruby>硬<rp>(</rp><rt>かた</rt><rp>)</rp></ruby>くても <ruby>溶解液<rp>(</rp><rt>ようかいえき</rt><rp>)</rp></ruby>で <ruby>跡形<rp>(</rp><rt>あとかた</rt><rp>)</rp></ruby>なく <ruby>溶<rp>(</rp><rt>と</rt><rp>)</rp></ruby>かされてしまう。"
+          },
+          "name": {
+            "jpn": "メガウツボット",
+            "eng": "Mega Victreebel"
           }
         }
       },
@@ -2589,21 +2649,25 @@
           "id": "0308_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガチャーレム",
           "gigantamax": null,
           "type1": "かくとう",
           "type2": "エスパー",
           "hp": 60,
-          "attack": 60,
-          "defense": 75,
-          "special_attack": 60,
-          "special_defense": 75,
-          "speed": 80,
-          "ability1": "",
+          "attack": 100,
+          "defense": 85,
+          "special_attack": 80,
+          "special_defense": 85,
+          "speed": 100,
+          "ability1": "ヨガパワー",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "ヨガの <ruby>修行<rp>(</rp><rt>しゅぎょう</rt><rp>)</rp></ruby>で <ruby>鍛<rp>(</rp><rt>きた</rt><rp>)</rp></ruby>えられた サイコパワーで <ruby>相手<rp>(</rp><rt>あいて</rt><rp>)</rp></ruby>の <ruby>動<rp>(</rp><rt>うご</rt><rp>)</rp></ruby>きを <ruby>予測<rp>(</rp><rt>よそく</rt><rp>)</rp></ruby>することが できるのだ。"
+          },
+          "name": {
+            "jpn": "メガチャーレム",
+            "eng": "Mega Medicham"
           }
         }
       },
@@ -2656,21 +2720,25 @@
           "id": "0310_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガライボルト",
           "gigantamax": null,
           "type1": "でんき",
           "type2": "",
           "hp": 70,
           "attack": 75,
-          "defense": 60,
-          "special_attack": 105,
-          "special_defense": 60,
-          "speed": 105,
-          "ability1": "",
+          "defense": 80,
+          "special_attack": 135,
+          "special_defense": 80,
+          "speed": 135,
+          "ability1": "いかく",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "たてがみから <ruby>放電<rp>(</rp><rt>ほうでん</rt><rp>)</rp></ruby>している。<ruby>頭上<rp>(</rp><rt>ずじょう</rt><rp>)</rp></ruby>に <ruby>雷雲<rp>(</rp><rt>かみなりぐも</rt><rp>)</rp></ruby>を <ruby>作<rp>(</rp><rt>つく</rt><rp>)</rp></ruby>り <ruby>稲妻<rp>(</rp><rt>いなずま</rt><rp>)</rp></ruby>を <ruby>落<rp>(</rp><rt>お</rt><rp>)</rp></ruby>として <ruby>攻撃<rp>(</rp><rt>こうげき</rt><rp>)</rp></ruby>する。"
+          },
+          "name": {
+            "jpn": "メガライボルト",
+            "eng": "Mega Manectric"
           }
         }
       },
@@ -2746,21 +2814,25 @@
           "id": "0282_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガサーナイト",
           "gigantamax": null,
           "type1": "エスパー",
           "type2": "フェアリー",
           "hp": 68,
-          "attack": 65,
+          "attack": 85,
           "defense": 65,
-          "special_attack": 125,
-          "special_defense": 115,
-          "speed": 80,
-          "ability1": "",
+          "special_attack": 165,
+          "special_defense": 135,
+          "speed": 100,
+          "ability1": "フェアリースキン",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>未来<rp>(</rp><rt>みらい</rt><rp>)</rp></ruby>を <ruby>予知<rp>(</rp><rt>よち</rt><rp>)</rp></ruby>する <ruby>力<rp>(</rp><rt>ちから</rt><rp>)</rp></ruby>を もつ。トレーナーを <ruby>守<rp>(</rp><rt>まも</rt><rp>)</rp></ruby>るときに <ruby>最大<rp>(</rp><rt>さいだい</rt><rp>)</rp></ruby> パワーを <ruby>発揮<rp>(</rp><rt>はっき</rt><rp>)</rp></ruby>する。"
+          },
+          "name": {
+            "jpn": "メガサーナイト",
+            "eng": "Mega Gardevoir"
           }
         }
       },
@@ -2790,21 +2862,25 @@
           "id": "0475_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガエルレイド",
           "gigantamax": null,
-          "type1": "かくとう",
-          "type2": "エスパー",
+          "type1": "エスパー",
+          "type2": "かくとう",
           "hp": 68,
-          "attack": 125,
-          "defense": 65,
+          "attack": 165,
+          "defense": 95,
           "special_attack": 65,
           "special_defense": 115,
-          "speed": 80,
-          "ability1": "",
+          "speed": 110,
+          "ability1": "せいしんりょく",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>伸<rp>(</rp><rt>の</rt><rp>)</rp></ruby>び<ruby>縮<rp>(</rp><rt>ちぢ</rt><rp>)</rp></ruby>みする ヒジの <ruby>刀<rp>(</rp><rt>かたな</rt><rp>)</rp></ruby>で <ruby>戦<rp>(</rp><rt>たたか</rt><rp>)</rp></ruby>う。<ruby>居合<rp>(</rp><rt>いあい</rt><rp>)</rp></ruby>の <ruby>名手<rp>(</rp><rt>めいしゅ</rt><rp>)</rp></ruby>。<ruby>礼儀正<rp>(</rp><rt>れいぎただ</rt><rp>)</rp></ruby>しい ポケモン。"
+          },
+          "name": {
+            "jpn": "メガエルレイド",
+            "eng": "Mega Gallade"
           }
         }
       },
@@ -2857,21 +2933,25 @@
           "id": "0229_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガヘルガー",
           "gigantamax": null,
-          "type1": "ほのお",
-          "type2": "あく",
+          "type1": "あく",
+          "type2": "ほのお",
           "hp": 75,
           "attack": 90,
-          "defense": 50,
-          "special_attack": 110,
-          "special_defense": 80,
-          "speed": 95,
-          "ability1": "",
+          "defense": 90,
+          "special_attack": 140,
+          "special_defense": 90,
+          "speed": 115,
+          "ability1": "サンパワー",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>怒<rp>(</rp><rt>おこ</rt><rp>)</rp></ruby>ったときに <ruby>口<rp>(</rp><rt>くち</rt><rp>)</rp></ruby>から <ruby>噴<rp>(</rp><rt>ふ</rt><rp>)</rp></ruby>き<ruby>出<rp>(</rp><rt>だ</rt><rp>)</rp></ruby>す <ruby>炎<rp>(</rp><rt>ほのお</rt><rp>)</rp></ruby>には <ruby>毒素<rp>(</rp><rt>どくそ</rt><rp>)</rp></ruby>も <ruby>混<rp>(</rp><rt>ま</rt><rp>)</rp></ruby>じっていて やけどになると いつまでも うずく。"
+          },
+          "name": {
+            "jpn": "メガヘルガー",
+            "eng": "Mega Houndoom"
           }
         }
       },
@@ -2924,21 +3004,25 @@
           "id": "0334_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガチルタリス",
           "gigantamax": null,
-          "type1": "ひこう",
-          "type2": "ドラゴン",
+          "type1": "ドラゴン",
+          "type2": "フェアリー",
           "hp": 75,
-          "attack": 70,
-          "defense": 90,
-          "special_attack": 70,
+          "attack": 110,
+          "defense": 110,
+          "special_attack": 110,
           "special_defense": 105,
           "speed": 80,
-          "ability1": "",
+          "ability1": "フェアリースキン",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>大空<rp>(</rp><rt>おおぞら</rt><rp>)</rp></ruby>を ゆったりと <ruby>飛<rp>(</rp><rt>と</rt><rp>)</rp></ruby>ぶ。チルタリスの <ruby>美<rp>(</rp><rt>うつく</rt><rp>)</rp></ruby>しい ハミングを <ruby>聴<rp>(</rp><rt>き</rt><rp>)</rp></ruby>くと うっとり <ruby>夢心地<rp>(</rp><rt>ゆめごこち</rt><rp>)</rp></ruby>だ。"
+          },
+          "name": {
+            "jpn": "メガチルタリス",
+            "eng": "Mega Altaria"
           }
         }
       },
@@ -2968,21 +3052,25 @@
           "id": "0531_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガタブンネ",
           "gigantamax": null,
           "type1": "ノーマル",
-          "type2": "",
+          "type2": "フェアリー",
           "hp": 103,
           "attack": 60,
-          "defense": 86,
-          "special_attack": 60,
-          "special_defense": 86,
+          "defense": 126,
+          "special_attack": 80,
+          "special_defense": 126,
           "speed": 50,
-          "ability1": "",
+          "ability1": "いやしのこころ",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>耳<rp>(</rp><rt>みみ</rt><rp>)</rp></ruby>の <ruby>触角<rp>(</rp><rt>しょっかく</rt><rp>)</rp></ruby>で <ruby>相手<rp>(</rp><rt>あいて</rt><rp>)</rp></ruby>に <ruby>触<rp>(</rp><rt>ふ</rt><rp>)</rp></ruby>れると <ruby>心臓<rp>(</rp><rt>しんぞう</rt><rp>)</rp></ruby>の <ruby>音<rp>(</rp><rt>おと</rt><rp>)</rp></ruby>で <ruby>体調<rp>(</rp><rt>たいちょう</rt><rp>)</rp></ruby>や <ruby>気持<rp>(</rp><rt>きも</rt><rp>)</rp></ruby>ちが わかるのだ。"
+          },
+          "name": {
+            "jpn": "メガタブンネ",
+            "eng": "Mega Audino"
           }
         }
       },
@@ -3334,21 +3422,25 @@
           "id": "0428_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガミミロップ",
           "gigantamax": null,
           "type1": "ノーマル",
-          "type2": "",
+          "type2": "かくとう",
           "hp": 65,
-          "attack": 76,
-          "defense": 84,
+          "attack": 136,
+          "defense": 94,
           "special_attack": 54,
           "special_defense": 96,
-          "speed": 105,
-          "ability1": "",
+          "speed": 135,
+          "ability1": "きもったま",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>耳<rp>(</rp><rt>みみ</rt><rp>)</rp></ruby>は とても デリケートらしく <ruby>優<rp>(</rp><rt>やさ</rt><rp>)</rp></ruby>しく <ruby>丁寧<rp>(</rp><rt>ていねい</rt><rp>)</rp></ruby>に <ruby>触<rp>(</rp><rt>さわ</rt><rp>)</rp></ruby>らないと しなやかな <ruby>脚<rp>(</rp><rt>あし</rt><rp>)</rp></ruby>で けられてしまう。"
+          },
+          "name": {
+            "jpn": "メガミミロップ",
+            "eng": "Mega Lopunny"
           }
         }
       },
@@ -3401,21 +3493,25 @@
           "id": "0354_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガジュペッタ",
           "gigantamax": null,
           "type1": "ゴースト",
           "type2": "",
           "hp": 64,
-          "attack": 115,
-          "defense": 65,
-          "special_attack": 83,
-          "special_defense": 63,
-          "speed": 65,
-          "ability1": "",
+          "attack": 165,
+          "defense": 75,
+          "special_attack": 93,
+          "special_defense": 83,
+          "speed": 75,
+          "ability1": "いたずらごころ",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>捨<rp>(</rp><rt>す</rt><rp>)</rp></ruby>てられた ぬいぐるみに おんねんが <ruby>宿<rp>(</rp><rt>やど</rt><rp>)</rp></ruby>り ポケモンになった。<ruby>自分<rp>(</rp><rt>じぶん</rt><rp>)</rp></ruby>を <ruby>捨<rp>(</rp><rt>す</rt><rp>)</rp></ruby>てた <ruby>子供<rp>(</rp><rt>こども</rt><rp>)</rp></ruby>を <ruby>捜<rp>(</rp><rt>さが</rt><rp>)</rp></ruby>している。"
+          },
+          "name": {
+            "jpn": "メガジュペッタ",
+            "eng": "Mega Banette"
           }
         }
       },
@@ -3537,21 +3633,25 @@
           "id": "0323_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガバクーダ",
           "gigantamax": null,
           "type1": "ほのお",
           "type2": "じめん",
           "hp": 70,
-          "attack": 100,
-          "defense": 70,
-          "special_attack": 105,
-          "special_defense": 75,
-          "speed": 40,
-          "ability1": "",
+          "attack": 120,
+          "defense": 100,
+          "special_attack": 145,
+          "special_defense": 105,
+          "speed": 20,
+          "ability1": "ちからずく",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>背中<rp>(</rp><rt>せなか</rt><rp>)</rp></ruby>の コブの <ruby>火山<rp>(</rp><rt>かざん</rt><rp>)</rp></ruby>は １０<ruby>年<rp>(</rp><rt>ねん</rt><rp>)</rp></ruby>ごとに <ruby>大噴火<rp>(</rp><rt>だいふんか</rt><rp>)</rp></ruby> するが <ruby>激<rp>(</rp><rt>はげ</rt><rp>)</rp></ruby>しく <ruby>怒<rp>(</rp><rt>おこ</rt><rp>)</rp></ruby>っても <ruby>噴火<rp>(</rp><rt>ふんか</rt><rp>)</rp></ruby>する。"
+          },
+          "name": {
+            "jpn": "メガバクーダ",
+            "eng": "Mega Camerupt"
           }
         }
       },
@@ -3650,21 +3750,25 @@
           "id": "0530_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガドリュウズ",
           "gigantamax": null,
           "type1": "じめん",
           "type2": "はがね",
           "hp": 110,
-          "attack": 135,
-          "defense": 60,
-          "special_attack": 50,
+          "attack": 165,
+          "defense": 100,
+          "special_attack": 65,
           "special_defense": 65,
-          "speed": 88,
+          "speed": 103,
           "ability1": "",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>地下<rp>(</rp><rt>ちか</rt><rp>)</rp></ruby> １００メートルに <ruby>迷路<rp>(</rp><rt>めいろ</rt><rp>)</rp></ruby>の ような <ruby>巣穴<rp>(</rp><rt>すあな</rt><rp>)</rp></ruby>を <ruby>掘<rp>(</rp><rt>ほ</rt><rp>)</rp></ruby>る。<ruby>地下鉄<rp>(</rp><rt>ちかてつ</rt><rp>)</rp></ruby>の トンネルに <ruby>穴<rp>(</rp><rt>あな</rt><rp>)</rp></ruby>を <ruby>開<rp>(</rp><rt>あ</rt><rp>)</rp></ruby>けてしまう。"
+          },
+          "name": {
+            "jpn": "メガドリュウズ",
+            "eng": "Mega Excadrill"
           }
         }
       },
@@ -3878,21 +3982,25 @@
           "id": "0445_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガガブリアス",
           "gigantamax": null,
-          "type1": "じめん",
-          "type2": "ドラゴン",
+          "type1": "ドラゴン",
+          "type2": "じめん",
           "hp": 108,
-          "attack": 130,
-          "defense": 95,
-          "special_attack": 80,
-          "special_defense": 85,
-          "speed": 102,
-          "ability1": "",
+          "attack": 170,
+          "defense": 115,
+          "special_attack": 120,
+          "special_defense": 95,
+          "speed": 92,
+          "ability1": "すなのちから",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "ジェット<ruby>戦闘機<rp>(</rp><rt>せんとうき</rt><rp>)</rp></ruby>に <ruby>負<rp>(</rp><rt>ま</rt><rp>)</rp></ruby>けない スピードで <ruby>空<rp>(</rp><rt>そら</rt><rp>)</rp></ruby>を <ruby>飛<rp>(</rp><rt>と</rt><rp>)</rp></ruby>ぶ。<ruby>狙<rp>(</rp><rt>ねら</rt><rp>)</rp></ruby>った <ruby>獲物<rp>(</rp><rt>えもの</rt><rp>)</rp></ruby>は <ruby>逃<rp>(</rp><rt>に</rt><rp>)</rp></ruby>がさない。"
+          },
+          "name": {
+            "jpn": "メガガブリアス",
+            "eng": "Mega Garchomp"
           }
         }
       },
@@ -3945,21 +4053,25 @@
           "id": "0302_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガヤミラミ",
           "gigantamax": null,
-          "type1": "ゴースト",
-          "type2": "あく",
+          "type1": "あく",
+          "type2": "ゴースト",
           "hp": 50,
-          "attack": 75,
-          "defense": 75,
-          "special_attack": 65,
-          "special_defense": 65,
-          "speed": 50,
-          "ability1": "",
+          "attack": 85,
+          "defense": 125,
+          "special_attack": 85,
+          "special_defense": 115,
+          "speed": 20,
+          "ability1": "マジックミラー",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>洞窟<rp>(</rp><rt>どうくつ</rt><rp>)</rp></ruby>の <ruby>暗闇<rp>(</rp><rt>くらやみ</rt><rp>)</rp></ruby>に <ruby>潜<rp>(</rp><rt>ひそ</rt><rp>)</rp></ruby>む。<ruby>宝石<rp>(</rp><rt>ほうせき</rt><rp>)</rp></ruby>を <ruby>食<rp>(</rp><rt>た</rt><rp>)</rp></ruby>べているうちに <ruby>目<rp>(</rp><rt>め</rt><rp>)</rp></ruby>が <ruby>宝石<rp>(</rp><rt>ほうせき</rt><rp>)</rp></ruby>に なってしまった。"
+          },
+          "name": {
+            "jpn": "メガヤミラミ",
+            "eng": "Mega Sableye"
           }
         }
       },
@@ -3989,21 +4101,25 @@
           "id": "0303_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガクチート",
           "gigantamax": null,
           "type1": "はがね",
           "type2": "フェアリー",
           "hp": 50,
-          "attack": 85,
-          "defense": 85,
+          "attack": 105,
+          "defense": 125,
           "special_attack": 55,
-          "special_defense": 55,
+          "special_defense": 95,
           "speed": 50,
-          "ability1": "",
+          "ability1": "ちからもち",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "ツノが <ruby>変形<rp>(</rp><rt>へんけい</rt><rp>)</rp></ruby>して できた <ruby>大<rp>(</rp><rt>おお</rt><rp>)</rp></ruby>あごが <ruby>頭<rp>(</rp><rt>あたま</rt><rp>)</rp></ruby>に ついている。<ruby>鉄骨<rp>(</rp><rt>てっこつ</rt><rp>)</rp></ruby>を <ruby>噛<rp>(</rp><rt>か</rt><rp>)</rp></ruby>み<ruby>切<rp>(</rp><rt>き</rt><rp>)</rp></ruby>ってしまう。"
+          },
+          "name": {
+            "jpn": "メガクチート",
+            "eng": "Mega Mawile"
           }
         }
       },
@@ -4033,21 +4149,25 @@
           "id": "0359_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガアブソル",
           "gigantamax": null,
           "type1": "あく",
           "type2": "",
           "hp": 65,
-          "attack": 130,
+          "attack": 150,
           "defense": 60,
-          "special_attack": 75,
+          "special_attack": 115,
           "special_defense": 60,
-          "speed": 75,
-          "ability1": "",
+          "speed": 115,
+          "ability1": "マジックミラー",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>災害<rp>(</rp><rt>さいがい</rt><rp>)</rp></ruby>を <ruby>予感<rp>(</rp><rt>よかん</rt><rp>)</rp></ruby>する。<ruby>危険<rp>(</rp><rt>きけん</rt><rp>)</rp></ruby>を <ruby>知<rp>(</rp><rt>し</rt><rp>)</rp></ruby>らせるときだけ <ruby>人前<rp>(</rp><rt>ひとまえ</rt><rp>)</rp></ruby>に <ruby>現<rp>(</rp><rt>あらわ</rt><rp>)</rp></ruby>れるという。"
+          },
+          "name": {
+            "jpn": "メガアブソル",
+            "eng": "Mega Absol"
           }
         }
       },
@@ -4100,21 +4220,25 @@
           "id": "0448_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガルカリオ",
           "gigantamax": null,
           "type1": "かくとう",
           "type2": "はがね",
           "hp": 70,
-          "attack": 110,
-          "defense": 70,
-          "special_attack": 115,
+          "attack": 145,
+          "defense": 88,
+          "special_attack": 140,
           "special_defense": 70,
-          "speed": 90,
-          "ability1": "",
+          "speed": 112,
+          "ability1": "てきおうりょく",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "あらゆる ものが <ruby>出<rp>(</rp><rt>だ</rt><rp>)</rp></ruby>す <ruby>波動<rp>(</rp><rt>はどう</rt><rp>)</rp></ruby>を <ruby>読<rp>(</rp><rt>よ</rt><rp>)</rp></ruby>みとることで １キロ<ruby>先<rp>(</rp><rt>さき</rt><rp>)</rp></ruby>に いる <ruby>相手<rp>(</rp><rt>あいて</rt><rp>)</rp></ruby>の <ruby>気持<rp>(</rp><rt>きも</rt><rp>)</rp></ruby>ちも <ruby>理解<rp>(</rp><rt>りかい</rt><rp>)</rp></ruby>できる。"
+          },
+          "name": {
+            "jpn": "メガルカリオ",
+            "eng": "Mega Lucario"
           }
         }
       },
@@ -4188,21 +4312,25 @@
           "id": "0080_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガヤドラン",
           "gigantamax": null,
           "type1": "みず",
           "type2": "エスパー",
           "hp": 95,
           "attack": 75,
-          "defense": 110,
-          "special_attack": 100,
+          "defense": 180,
+          "special_attack": 130,
           "special_defense": 80,
           "speed": 30,
-          "ability1": "",
+          "ability1": "シェルアーマー",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "くっついている シェルダーは <ruby>尻尾<rp>(</rp><rt>しっぽ</rt><rp>)</rp></ruby>から にじみでる うま<ruby>味<rp>(</rp><rt>み</rt><rp>)</rp></ruby>が <ruby>欲<rp>(</rp><rt>ほ</rt><rp>)</rp></ruby>しくて ずっと <ruby>離<rp>(</rp><rt>はな</rt><rp>)</rp></ruby>れない。"
+          },
+          "name": {
+            "jpn": "メガヤドラン",
+            "eng": "Mega Slowbro"
           }
         },
         "0080_02000000_0_000_0": {
@@ -4320,21 +4448,25 @@
           "id": "0319_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガサメハダー",
           "gigantamax": null,
           "type1": "みず",
           "type2": "あく",
           "hp": 70,
-          "attack": 120,
-          "defense": 40,
-          "special_attack": 95,
-          "special_defense": 40,
-          "speed": 95,
-          "ability1": "",
+          "attack": 140,
+          "defense": 70,
+          "special_attack": 110,
+          "special_defense": 65,
+          "speed": 105,
+          "ability1": "がんじょうあご",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "お<ruby>尻<rp>(</rp><rt>しり</rt><rp>)</rp></ruby>から <ruby>海水<rp>(</rp><rt>かいすい</rt><rp>)</rp></ruby>を <ruby>噴射<rp>(</rp><rt>ふんしゃ</rt><rp>)</rp></ruby>して <ruby>時速<rp>(</rp><rt>じそく</rt><rp>)</rp></ruby>１２０キロの スピードで <ruby>泳<rp>(</rp><rt>およ</rt><rp>)</rp></ruby>ぎまわる <ruby>海<rp>(</rp><rt>うみ</rt><rp>)</rp></ruby>の <ruby>暴<rp>(</rp><rt>あば</rt><rp>)</rp></ruby>れん<ruby>坊<rp>(</rp><rt>ぼう</rt><rp>)</rp></ruby>。"
+          },
+          "name": {
+            "jpn": "メガサメハダー",
+            "eng": "Mega Sharpedo"
           }
         }
       },
@@ -4410,21 +4542,25 @@
           "id": "0604_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガシビルドン",
           "gigantamax": null,
           "type1": "でんき",
           "type2": "",
           "hp": 85,
-          "attack": 115,
+          "attack": 145,
           "defense": 80,
-          "special_attack": 105,
-          "special_defense": 80,
-          "speed": 50,
+          "special_attack": 135,
+          "special_defense": 90,
+          "speed": 80,
           "ability1": "",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>吸盤<rp>(</rp><rt>きゅうばん</rt><rp>)</rp></ruby>の <ruby>口<rp>(</rp><rt>くち</rt><rp>)</rp></ruby>で <ruby>獲物<rp>(</rp><rt>えもの</rt><rp>)</rp></ruby>に <ruby>吸<rp>(</rp><rt>す</rt><rp>)</rp></ruby>いつき <ruby>食<rp>(</rp><rt>く</rt><rp>)</rp></ruby>いこませた キバから <ruby>電気<rp>(</rp><rt>でんき</rt><rp>)</rp></ruby>を <ruby>流<rp>(</rp><rt>なが</rt><rp>)</rp></ruby>して <ruby>感電<rp>(</rp><rt>かんでん</rt><rp>)</rp></ruby>させる。"
+          },
+          "name": {
+            "jpn": "メガシビルドン",
+            "eng": "Mega Eelektross"
           }
         }
       },
@@ -4500,21 +4636,25 @@
           "id": "0149_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガカイリュー",
           "gigantamax": null,
-          "type1": "ひこう",
-          "type2": "ドラゴン",
+          "type1": "ドラゴン",
+          "type2": "ひこう",
           "hp": 91,
-          "attack": 134,
-          "defense": 95,
-          "special_attack": 100,
-          "special_defense": 100,
-          "speed": 80,
+          "attack": 124,
+          "defense": 115,
+          "special_attack": 145,
+          "special_defense": 125,
+          "speed": 100,
           "ability1": "",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>広<rp>(</rp><rt>ひろ</rt><rp>)</rp></ruby>い <ruby>海<rp>(</rp><rt>うみ</rt><rp>)</rp></ruby>の どこかに <ruby>棲<rp>(</rp><rt>す</rt><rp>)</rp></ruby>み<ruby>処<rp>(</rp><rt>か</rt><rp>)</rp></ruby>が あると いわれている。<ruby>難破<rp>(</rp><rt>なんぱ</rt><rp>)</rp></ruby>した <ruby>船<rp>(</rp><rt>ふね</rt><rp>)</rp></ruby>を <ruby>陸<rp>(</rp><rt>りく</rt><rp>)</rp></ruby>まで <ruby>導<rp>(</rp><rt>みちび</rt><rp>)</rp></ruby>いてくれる。"
+          },
+          "name": {
+            "jpn": "メガカイリュー",
+            "eng": "Mega Dragonite"
           }
         }
       },
@@ -4590,21 +4730,25 @@
           "id": "0003_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガフシギバナ",
           "gigantamax": null,
           "type1": "くさ",
           "type2": "どく",
           "hp": 80,
-          "attack": 82,
-          "defense": 83,
-          "special_attack": 100,
-          "special_defense": 100,
+          "attack": 100,
+          "defense": 123,
+          "special_attack": 122,
+          "special_defense": 120,
           "speed": 80,
-          "ability1": "",
+          "ability1": "あついしぼう",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>雨<rp>(</rp><rt>あめ</rt><rp>)</rp></ruby>の <ruby>降<rp>(</rp><rt>ふ</rt><rp>)</rp></ruby>った <ruby>翌日<rp>(</rp><rt>よくじつ</rt><rp>)</rp></ruby>は <ruby>背中<rp>(</rp><rt>せなか</rt><rp>)</rp></ruby>の <ruby>花<rp>(</rp><rt>はな</rt><rp>)</rp></ruby>の<ruby>香<rp>(</rp><rt>かお</rt><rp>)</rp></ruby>りが <ruby>強<rp>(</rp><rt>つよ</rt><rp>)</rp></ruby>まる。<ruby>香<rp>(</rp><rt>かお</rt><rp>)</rp></ruby>りに <ruby>誘<rp>(</rp><rt>さそ</rt><rp>)</rp></ruby>われ ポケモンが <ruby>集<rp>(</rp><rt>あつ</rt><rp>)</rp></ruby>まる。"
+          },
+          "name": {
+            "jpn": "メガフシギバナ",
+            "eng": "Mega Venusaur"
           }
         }
       },
@@ -4680,42 +4824,50 @@
           "id": "0006_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガリザードンX",
           "gigantamax": null,
           "type1": "ほのお",
-          "type2": "ひこう",
+          "type2": "ドラゴン",
           "hp": 78,
-          "attack": 84,
-          "defense": 78,
-          "special_attack": 109,
+          "attack": 130,
+          "defense": 111,
+          "special_attack": 130,
           "special_defense": 85,
           "speed": 100,
-          "ability1": "",
+          "ability1": "かたいツメ",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>地上<rp>(</rp><rt>ちじょう</rt><rp>)</rp></ruby> １４００メートルまで <ruby>羽<rp>(</rp><rt>はね</rt><rp>)</rp></ruby>を <ruby>使<rp>(</rp><rt>つか</rt><rp>)</rp></ruby>って <ruby>飛<rp>(</rp><rt>と</rt><rp>)</rp></ruby>ぶことができる。<ruby>高熱<rp>(</rp><rt>こうねつ</rt><rp>)</rp></ruby>の <ruby>炎<rp>(</rp><rt>ほのお</rt><rp>)</rp></ruby>を <ruby>吐<rp>(</rp><rt>は</rt><rp>)</rp></ruby>く。"
+          },
+          "name": {
+            "jpn": "メガリザードンX",
+            "eng": "Mega Charizard X"
           }
         },
         "0006_00000101_0_000_0": {
           "id": "0006_00000101_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガリザードンY",
           "gigantamax": null,
           "type1": "ほのお",
-          "type2": "ドラゴン",
+          "type2": "ひこう",
           "hp": 78,
-          "attack": 84,
+          "attack": 104,
           "defense": 78,
-          "special_attack": 109,
-          "special_defense": 85,
+          "special_attack": 159,
+          "special_defense": 115,
           "speed": 100,
-          "ability1": "",
+          "ability1": "ひでり",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>地上<rp>(</rp><rt>ちじょう</rt><rp>)</rp></ruby> １４００メートルまで <ruby>羽<rp>(</rp><rt>はね</rt><rp>)</rp></ruby>を <ruby>使<rp>(</rp><rt>つか</rt><rp>)</rp></ruby>って <ruby>飛<rp>(</rp><rt>と</rt><rp>)</rp></ruby>ぶことができる。<ruby>高熱<rp>(</rp><rt>こうねつ</rt><rp>)</rp></ruby>の <ruby>炎<rp>(</rp><rt>ほのお</rt><rp>)</rp></ruby>を <ruby>吐<rp>(</rp><rt>は</rt><rp>)</rp></ruby>く。"
+          },
+          "name": {
+            "jpn": "メガリザードンY",
+            "eng": "Mega Charizard Y"
           }
         }
       },
@@ -4791,21 +4943,25 @@
           "id": "0009_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガカメックス",
           "gigantamax": null,
           "type1": "みず",
           "type2": "",
           "hp": 79,
-          "attack": 83,
-          "defense": 100,
-          "special_attack": 85,
-          "special_defense": 105,
+          "attack": 103,
+          "defense": 120,
+          "special_attack": 135,
+          "special_defense": 115,
           "speed": 78,
-          "ability1": "",
+          "ability1": "メガランチャー",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>体<rp>(</rp><rt>からだ</rt><rp>)</rp></ruby>が <ruby>重<rp>(</rp><rt>おも</rt><rp>)</rp></ruby>たく のしかかって <ruby>相手<rp>(</rp><rt>あいて</rt><rp>)</rp></ruby>を <ruby>気絶<rp>(</rp><rt>きぜつ</rt><rp>)</rp></ruby>させる。ピンチのときは <ruby>殻<rp>(</rp><rt>から</rt><rp>)</rp></ruby>に <ruby>隠<rp>(</rp><rt>かく</rt><rp>)</rp></ruby>れる。"
+          },
+          "name": {
+            "jpn": "メガカメックス",
+            "eng": "Mega Blastoise"
           }
         }
       },
@@ -4925,21 +5081,25 @@
           "id": "0687_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガカラマネロ",
           "gigantamax": null,
-          "type1": "エスパー",
-          "type2": "あく",
+          "type1": "あく",
+          "type2": "エスパー",
           "hp": 86,
-          "attack": 92,
+          "attack": 102,
           "defense": 88,
-          "special_attack": 68,
-          "special_defense": 75,
-          "speed": 73,
+          "special_attack": 98,
+          "special_defense": 120,
+          "speed": 88,
           "ability1": "",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "ポケモンで <ruby>一番<rp>(</rp><rt>いちばん</rt><rp>)</rp></ruby> <ruby>強力<rp>(</rp><rt>きょうりょく</rt><rp>)</rp></ruby>な <ruby>催眠術<rp>(</rp><rt>さいみんじゅつ</rt><rp>)</rp></ruby>を <ruby>使<rp>(</rp><rt>つか</rt><rp>)</rp></ruby>う。<ruby>相手<rp>(</rp><rt>あいて</rt><rp>)</rp></ruby>を <ruby>意<rp>(</rp><rt>い</rt><rp>)</rp></ruby>のままに <ruby>操<rp>(</rp><rt>あやつ</rt><rp>)</rp></ruby>ってしまうのだ。"
+          },
+          "name": {
+            "jpn": "メガカラマネロ",
+            "eng": "Mega Malamar"
           }
         }
       },
@@ -4992,21 +5152,25 @@
           "id": "0691_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガドラミドロ",
           "gigantamax": null,
           "type1": "どく",
           "type2": "ドラゴン",
           "hp": 65,
-          "attack": 75,
-          "defense": 90,
-          "special_attack": 97,
-          "special_defense": 123,
+          "attack": 85,
+          "defense": 105,
+          "special_attack": 132,
+          "special_defense": 163,
           "speed": 44,
           "ability1": "",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "タンカーの <ruby>船体<rp>(</rp><rt>せんたい</rt><rp>)</rp></ruby>を <ruby>腐<rp>(</rp><rt>くさ</rt><rp>)</rp></ruby>らせる <ruby>猛毒<rp>(</rp><rt>もうどく</rt><rp>)</rp></ruby>を <ruby>縄張<rp>(</rp><rt>なわば</rt><rp>)</rp></ruby>りに <ruby>入<rp>(</rp><rt>はい</rt><rp>)</rp></ruby>りこんだ ものに <ruby>見境<rp>(</rp><rt>みさかい</rt><rp>)</rp></ruby>なく <ruby>吐<rp>(</rp><rt>は</rt><rp>)</rp></ruby>きかける。"
+          },
+          "name": {
+            "jpn": "メガドラミドロ",
+            "eng": "Mega Dragalge"
           }
         }
       },
@@ -5197,21 +5361,25 @@
           "id": "0362_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガオニゴーリ",
           "gigantamax": null,
           "type1": "こおり",
           "type2": "",
           "hp": 80,
-          "attack": 80,
+          "attack": 120,
           "defense": 80,
-          "special_attack": 80,
+          "special_attack": 120,
           "special_defense": 80,
-          "speed": 80,
-          "ability1": "",
+          "speed": 100,
+          "ability1": "フリーズスキン",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>空気中<rp>(</rp><rt>くうきちゅう</rt><rp>)</rp></ruby>の <ruby>水分<rp>(</rp><rt>すいぶん</rt><rp>)</rp></ruby>を <ruby>凍<rp>(</rp><rt>こお</rt><rp>)</rp></ruby>らせ <ruby>氷<rp>(</rp><rt>こおり</rt><rp>)</rp></ruby>の <ruby>装甲<rp>(</rp><rt>そうこう</rt><rp>)</rp></ruby>で <ruby>体<rp>(</rp><rt>からだ</rt><rp>)</rp></ruby>を <ruby>包<rp>(</rp><rt>つつ</rt><rp>)</rp></ruby>みこみ <ruby>身<rp>(</rp><rt>み</rt><rp>)</rp></ruby>を <ruby>守<rp>(</rp><rt>まも</rt><rp>)</rp></ruby>っている。"
+          },
+          "name": {
+            "jpn": "メガオニゴーリ",
+            "eng": "Mega Glalie"
           }
         }
       },
@@ -5241,21 +5409,25 @@
           "id": "0478_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガユキメノコ",
           "gigantamax": null,
           "type1": "こおり",
           "type2": "ゴースト",
           "hp": 70,
           "attack": 80,
           "defense": 70,
-          "special_attack": 80,
-          "special_defense": 70,
-          "speed": 110,
+          "special_attack": 140,
+          "special_defense": 100,
+          "speed": 120,
           "ability1": "",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "マイナス５０<ruby>度<rp>(</rp><rt>ど</rt><rp>)</rp></ruby>の <ruby>冷気<rp>(</rp><rt>れいき</rt><rp>)</rp></ruby>を <ruby>吐<rp>(</rp><rt>は</rt><rp>)</rp></ruby>いて <ruby>相手<rp>(</rp><rt>あいて</rt><rp>)</rp></ruby>を <ruby>凍<rp>(</rp><rt>こお</rt><rp>)</rp></ruby>らせる。<ruby>胴体<rp>(</rp><rt>どうたい</rt><rp>)</rp></ruby>に <ruby>見<rp>(</rp><rt>み</rt><rp>)</rp></ruby>える <ruby>部分<rp>(</rp><rt>ぶぶん</rt><rp>)</rp></ruby>は じつは <ruby>空洞<rp>(</rp><rt>くうどう</rt><rp>)</rp></ruby>。"
+          },
+          "name": {
+            "jpn": "メガユキメノコ",
+            "eng": "Mega Froslass"
           }
         }
       },
@@ -5308,21 +5480,25 @@
           "id": "0460_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガユキノオー",
           "gigantamax": null,
           "type1": "くさ",
           "type2": "こおり",
           "hp": 90,
-          "attack": 92,
-          "defense": 75,
-          "special_attack": 92,
-          "special_defense": 85,
-          "speed": 60,
-          "ability1": "",
+          "attack": 132,
+          "defense": 105,
+          "special_attack": 132,
+          "special_defense": 105,
+          "speed": 30,
+          "ability1": "ゆきふらし",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "ブリザードを <ruby>発生<rp>(</rp><rt>はっせい</rt><rp>)</rp></ruby>させて あたり <ruby>一面<rp>(</rp><rt>いちめん</rt><rp>)</rp></ruby>を <ruby>真<rp>(</rp><rt>ま</rt><rp>)</rp></ruby>っ<ruby>白<rp>(</rp><rt>しろ</rt><rp>)</rp></ruby>に してしまう。<ruby>別名<rp>(</rp><rt>べつめい</rt><rp>)</rp></ruby> アイスモンスター。"
+          },
+          "name": {
+            "jpn": "メガユキノオー",
+            "eng": "Mega Abomasnow"
           }
         }
       },
@@ -5421,21 +5597,25 @@
           "id": "0212_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガハッサム",
           "gigantamax": null,
           "type1": "むし",
           "type2": "はがね",
           "hp": 70,
-          "attack": 130,
-          "defense": 100,
-          "special_attack": 55,
-          "special_defense": 80,
-          "speed": 65,
-          "ability1": "",
+          "attack": 150,
+          "defense": 140,
+          "special_attack": 65,
+          "special_defense": 100,
+          "speed": 75,
+          "ability1": "テクニシャン",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>鋼<rp>(</rp><rt>はがね</rt><rp>)</rp></ruby>の <ruby>体<rp>(</rp><rt>からだ</rt><rp>)</rp></ruby>を <ruby>持<rp>(</rp><rt>も</rt><rp>)</rp></ruby>つ。<ruby>目玉模様<rp>(</rp><rt>めだまもよう</rt><rp>)</rp></ruby>の ついた ハサミを <ruby>振<rp>(</rp><rt>ふ</rt><rp>)</rp></ruby>り<ruby>上<rp>(</rp><rt>あ</rt><rp>)</rp></ruby>げて <ruby>相手<rp>(</rp><rt>あいて</rt><rp>)</rp></ruby>を <ruby>威嚇<rp>(</rp><rt>いかく</rt><rp>)</rp></ruby>する。"
+          },
+          "name": {
+            "jpn": "メガハッサム",
+            "eng": "Mega Scizor"
           }
         }
       },
@@ -5465,21 +5645,25 @@
           "id": "0127_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガカイロス",
           "gigantamax": null,
           "type1": "むし",
-          "type2": "",
+          "type2": "ひこう",
           "hp": 65,
-          "attack": 125,
-          "defense": 100,
-          "special_attack": 55,
-          "special_defense": 70,
-          "speed": 85,
-          "ability1": "",
+          "attack": 155,
+          "defense": 120,
+          "special_attack": 65,
+          "special_defense": 90,
+          "speed": 105,
+          "ability1": "スカイスキン",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>長<rp>(</rp><rt>なが</rt><rp>)</rp></ruby>い ツノを <ruby>振<rp>(</rp><rt>ふ</rt><rp>)</rp></ruby>りまわして <ruby>攻撃<rp>(</rp><rt>こうげき</rt><rp>)</rp></ruby>してくる。<ruby>寒<rp>(</rp><rt>さむ</rt><rp>)</rp></ruby>いときは <ruby>森<rp>(</rp><rt>もり</rt><rp>)</rp></ruby>の <ruby>奥<rp>(</rp><rt>おく</rt><rp>)</rp></ruby>に <ruby>姿<rp>(</rp><rt>すがた</rt><rp>)</rp></ruby>を <ruby>隠<rp>(</rp><rt>かく</rt><rp>)</rp></ruby>す。"
+          },
+          "name": {
+            "jpn": "メガカイロス",
+            "eng": "Mega Pinsir"
           }
         }
       },
@@ -5509,21 +5693,25 @@
           "id": "0214_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガヘラクロス",
           "gigantamax": null,
-          "type1": "かくとう",
-          "type2": "むし",
+          "type1": "むし",
+          "type2": "かくとう",
           "hp": 80,
-          "attack": 125,
-          "defense": 75,
-          "special_attack": 40,
-          "special_defense": 95,
-          "speed": 85,
-          "ability1": "",
+          "attack": 185,
+          "defense": 115,
+          "special_attack": 65,
+          "special_defense": 105,
+          "speed": 75,
+          "ability1": "スキルリンク",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>自慢<rp>(</rp><rt>じまん</rt><rp>)</rp></ruby>のツノを <ruby>相手<rp>(</rp><rt>あいて</rt><rp>)</rp></ruby>の お<ruby>腹<rp>(</rp><rt>なか</rt><rp>)</rp></ruby>の <ruby>下<rp>(</rp><rt>した</rt><rp>)</rp></ruby>に ねじこみ <ruby>一気<rp>(</rp><rt>いっき</rt><rp>)</rp></ruby>に <ruby>持<rp>(</rp><rt>も</rt><rp>)</rp></ruby>ち<ruby>上<rp>(</rp><rt>あ</rt><rp>)</rp></ruby>げ ぶん<ruby>投<rp>(</rp><rt>な</rt><rp>)</rp></ruby>げてしまう <ruby>力持<rp>(</rp><rt>ちからも</rt><rp>)</rp></ruby>ち。"
+          },
+          "name": {
+            "jpn": "メガヘラクロス",
+            "eng": "Mega Heracross"
           }
         }
       },
@@ -5576,21 +5764,25 @@
           "id": "0701_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガルチャブル",
           "gigantamax": null,
           "type1": "かくとう",
           "type2": "ひこう",
           "hp": 78,
-          "attack": 92,
-          "defense": 75,
+          "attack": 137,
+          "defense": 100,
           "special_attack": 74,
-          "special_defense": 63,
+          "special_defense": 93,
           "speed": 118,
           "ability1": "",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>翼<rp>(</rp><rt>つばさ</rt><rp>)</rp></ruby>を <ruby>使<rp>(</rp><rt>つか</rt><rp>)</rp></ruby>い <ruby>空中<rp>(</rp><rt>くうちゅう</rt><rp>)</rp></ruby>で <ruby>姿勢<rp>(</rp><rt>しせい</rt><rp>)</rp></ruby>を <ruby>制御<rp>(</rp><rt>せいぎょ</rt><rp>)</rp></ruby>。<ruby>防<rp>(</rp><rt>ふせ</rt><rp>)</rp></ruby>ぎにくい <ruby>頭上<rp>(</rp><rt>ずじょう</rt><rp>)</rp></ruby>から <ruby>攻撃<rp>(</rp><rt>こうげき</rt><rp>)</rp></ruby>を <ruby>仕掛<rp>(</rp><rt>しか</rt><rp>)</rp></ruby>ける。"
+          },
+          "name": {
+            "jpn": "メガルチャブル",
+            "eng": "Mega Hawlucha"
           }
         }
       },
@@ -5689,21 +5881,25 @@
           "id": "0560_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガズルズキン",
           "gigantamax": null,
-          "type1": "かくとう",
-          "type2": "あく",
+          "type1": "あく",
+          "type2": "かくとう",
           "hp": 65,
-          "attack": 90,
-          "defense": 115,
-          "special_attack": 45,
-          "special_defense": 115,
-          "speed": 58,
+          "attack": 130,
+          "defense": 135,
+          "special_attack": 55,
+          "special_defense": 135,
+          "speed": 68,
           "ability1": "",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>脱皮<rp>(</rp><rt>だっぴ</rt><rp>)</rp></ruby>した <ruby>皮<rp>(</rp><rt>かわ</rt><rp>)</rp></ruby>を ずり<ruby>上<rp>(</rp><rt>あ</rt><rp>)</rp></ruby>げて ダメージを <ruby>減<rp>(</rp><rt>へ</rt><rp>)</rp></ruby>らしつつ キック！ とさかが <ruby>大<rp>(</rp><rt>おお</rt><rp>)</rp></ruby>きいほど <ruby>偉<rp>(</rp><rt>えら</rt><rp>)</rp></ruby>そうだ。"
+          },
+          "name": {
+            "jpn": "メガズルズキン",
+            "eng": "Mega Scrafty"
           }
         }
       },
@@ -5848,21 +6044,25 @@
           "id": "0609_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガシャンデラ",
           "gigantamax": null,
-          "type1": "ほのお",
-          "type2": "ゴースト",
+          "type1": "ゴースト",
+          "type2": "ほのお",
           "hp": 60,
-          "attack": 55,
-          "defense": 90,
-          "special_attack": 145,
-          "special_defense": 90,
-          "speed": 80,
+          "attack": 75,
+          "defense": 110,
+          "special_attack": 175,
+          "special_defense": 110,
+          "speed": 90,
           "ability1": "",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "シャンデラの <ruby>炎<rp>(</rp><rt>ほのお</rt><rp>)</rp></ruby>に <ruby>包<rp>(</rp><rt>つつ</rt><rp>)</rp></ruby>まれると <ruby>魂<rp>(</rp><rt>たましい</rt><rp>)</rp></ruby>が <ruby>吸<rp>(</rp><rt>す</rt><rp>)</rp></ruby>い<ruby>取<rp>(</rp><rt>と</rt><rp>)</rp></ruby>られ <ruby>燃<rp>(</rp><rt>も</rt><rp>)</rp></ruby>やされる。<ruby>抜<rp>(</rp><rt>ぬ</rt><rp>)</rp></ruby>け<ruby>殻<rp>(</rp><rt>がら</rt><rp>)</rp></ruby>の <ruby>体<rp>(</rp><rt>からだ</rt><rp>)</rp></ruby> だけが <ruby>残<rp>(</rp><rt>のこ</rt><rp>)</rp></ruby>る。"
+          },
+          "name": {
+            "jpn": "メガシャンデラ",
+            "eng": "Mega Chandelure"
           }
         }
       },
@@ -5892,21 +6092,25 @@
           "id": "0142_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガプテラ",
           "gigantamax": null,
-          "type1": "ひこう",
-          "type2": "いわ",
+          "type1": "いわ",
+          "type2": "ひこう",
           "hp": 80,
-          "attack": 105,
-          "defense": 65,
-          "special_attack": 60,
-          "special_defense": 75,
-          "speed": 130,
-          "ability1": "",
+          "attack": 135,
+          "defense": 85,
+          "special_attack": 70,
+          "special_defense": 95,
+          "speed": 150,
+          "ability1": "かたいツメ",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "コハクに <ruby>残<rp>(</rp><rt>のこ</rt><rp>)</rp></ruby>された <ruby>恐竜<rp>(</rp><rt>きょうりゅう</rt><rp>)</rp></ruby>の <ruby>遺伝子<rp>(</rp><rt>いでんし</rt><rp>)</rp></ruby>から <ruby>復活<rp>(</rp><rt>ふっかつ</rt><rp>)</rp></ruby>させた。<ruby>高<rp>(</rp><rt>たか</rt><rp>)</rp></ruby>い<ruby>声<rp>(</rp><rt>こえ</rt><rp>)</rp></ruby>で <ruby>鳴<rp>(</rp><rt>な</rt><rp>)</rp></ruby>きながら <ruby>飛<rp>(</rp><rt>と</rt><rp>)</rp></ruby>ぶ。"
+          },
+          "name": {
+            "jpn": "メガプテラ",
+            "eng": "Mega Aerodactyl"
           }
         }
       },
@@ -6051,21 +6255,25 @@
           "id": "0208_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガハガネール",
           "gigantamax": null,
-          "type1": "じめん",
-          "type2": "はがね",
+          "type1": "はがね",
+          "type2": "じめん",
           "hp": 75,
-          "attack": 85,
-          "defense": 200,
+          "attack": 125,
+          "defense": 230,
           "special_attack": 55,
-          "special_defense": 65,
+          "special_defense": 95,
           "speed": 30,
-          "ability1": "",
+          "ability1": "すなのちから",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>丈夫<rp>(</rp><rt>じょうぶ</rt><rp>)</rp></ruby>な あごで <ruby>岩石<rp>(</rp><rt>がんせき</rt><rp>)</rp></ruby>を かみくだき <ruby>進<rp>(</rp><rt>すす</rt><rp>)</rp></ruby>む。<ruby>真<rp>(</rp><rt>ま</rt><rp>)</rp></ruby>っ<ruby>暗<rp>(</rp><rt>くら</rt><rp>)</rp></ruby>な <ruby>地中<rp>(</rp><rt>ちちゅう</rt><rp>)</rp></ruby>でも <ruby>見<rp>(</rp><rt>み</rt><rp>)</rp></ruby>える <ruby>目<rp>(</rp><rt>め</rt><rp>)</rp></ruby>を <ruby>持<rp>(</rp><rt>も</rt><rp>)</rp></ruby>つ。"
+          },
+          "name": {
+            "jpn": "メガハガネール",
+            "eng": "Mega Steelix"
           }
         }
       },
@@ -6141,21 +6349,25 @@
           "id": "0306_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガボスゴドラ",
           "gigantamax": null,
-          "type1": "いわ",
-          "type2": "はがね",
+          "type1": "はがね",
+          "type2": "",
           "hp": 70,
-          "attack": 110,
-          "defense": 180,
+          "attack": 140,
+          "defense": 230,
           "special_attack": 60,
-          "special_defense": 60,
+          "special_defense": 80,
           "speed": 50,
-          "ability1": "",
+          "ability1": "フィルター",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>山<rp>(</rp><rt>やま</rt><rp>)</rp></ruby>を まるごと <ruby>縄張<rp>(</rp><rt>なわば</rt><rp>)</rp></ruby>りに する。<ruby>傷<rp>(</rp><rt>きず</rt><rp>)</rp></ruby>が <ruby>多<rp>(</rp><rt>おお</rt><rp>)</rp></ruby>い ボスゴドラほど <ruby>戦<rp>(</rp><rt>たたか</rt><rp>)</rp></ruby>っているので <ruby>侮<rp>(</rp><rt>あなど</rt><rp>)</rp></ruby>れない。"
+          },
+          "name": {
+            "jpn": "メガボスゴドラ",
+            "eng": "Mega Aggron"
           }
         }
       },
@@ -6449,21 +6661,25 @@
           "id": "0248_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガバンギラス",
           "gigantamax": null,
           "type1": "いわ",
           "type2": "あく",
           "hp": 100,
-          "attack": 134,
-          "defense": 110,
+          "attack": 164,
+          "defense": 150,
           "special_attack": 95,
-          "special_defense": 100,
-          "speed": 61,
-          "ability1": "",
+          "special_defense": 120,
+          "speed": 71,
+          "ability1": "すなおこし",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "バンギラスが <ruby>暴<rp>(</rp><rt>あば</rt><rp>)</rp></ruby>れると <ruby>山<rp>(</rp><rt>やま</rt><rp>)</rp></ruby>が <ruby>崩<rp>(</rp><rt>くず</rt><rp>)</rp></ruby>れ <ruby>川<rp>(</rp><rt>かわ</rt><rp>)</rp></ruby>が <ruby>埋<rp>(</rp><rt>う</rt><rp>)</rp></ruby>まるため <ruby>地図<rp>(</rp><rt>ちず</rt><rp>)</rp></ruby>を <ruby>書<rp>(</rp><rt>か</rt><rp>)</rp></ruby>き<ruby>換<rp>(</rp><rt>か</rt><rp>)</rp></ruby>えることになる。"
+          },
+          "name": {
+            "jpn": "メガバンギラス",
+            "eng": "Mega Tyranitar"
           }
         }
       },
@@ -6539,21 +6755,25 @@
           "id": "0658_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガゲッコウガ",
           "gigantamax": null,
           "type1": "みず",
           "type2": "あく",
           "hp": 72,
-          "attack": 95,
-          "defense": 67,
-          "special_attack": 103,
-          "special_defense": 71,
-          "speed": 122,
+          "attack": 125,
+          "defense": 77,
+          "special_attack": 133,
+          "special_defense": 81,
+          "speed": 142,
           "ability1": "",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>水<rp>(</rp><rt>みず</rt><rp>)</rp></ruby>を <ruby>圧縮<rp>(</rp><rt>あっしゅく</rt><rp>)</rp></ruby>して <ruby>手裏剣<rp>(</rp><rt>しゅりけん</rt><rp>)</rp></ruby>を <ruby>作<rp>(</rp><rt>つく</rt><rp>)</rp></ruby>り<ruby>出<rp>(</rp><rt>だ</rt><rp>)</rp></ruby>す。<ruby>高速回転<rp>(</rp><rt>こうそくかいてん</rt><rp>)</rp></ruby>させて <ruby>飛<rp>(</rp><rt>と</rt><rp>)</rp></ruby>ばすと <ruby>金属<rp>(</rp><rt>きんぞく</rt><rp>)</rp></ruby>も <ruby>真<rp>(</rp><rt>ま</rt><rp>)</rp></ruby>っ<ruby>二<rp>(</rp><rt>ぷた</rt><rp>)</rp></ruby>つ。"
+          },
+          "name": {
+            "jpn": "メガゲッコウガ",
+            "eng": "Mega Greninja"
           }
         }
       },
@@ -6583,21 +6803,25 @@
           "id": "0870_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガタイレーツ",
           "gigantamax": null,
           "type1": "かくとう",
           "type2": "",
           "hp": 65,
-          "attack": 100,
-          "defense": 100,
+          "attack": 135,
+          "defense": 135,
           "special_attack": 70,
-          "special_defense": 60,
-          "speed": 75,
+          "special_defense": 65,
+          "speed": 100,
           "ability1": "",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "ヘイチョーと <ruby>呼<rp>(</rp><rt>よ</rt><rp>)</rp></ruby>ばれる １<ruby>匹<rp>(</rp><rt>ぴき</rt><rp>)</rp></ruby>と ヘイと <ruby>呼<rp>(</rp><rt>よ</rt><rp>)</rp></ruby>ばれる ５<ruby>匹<rp>(</rp><rt>ひき</rt><rp>)</rp></ruby>で ひとつ。ヘイチョーの <ruby>命令<rp>(</rp><rt>めいれい</rt><rp>)</rp></ruby>は <ruby>絶対<rp>(</rp><rt>ぜったい</rt><rp>)</rp></ruby>。"
+          },
+          "name": {
+            "jpn": "メガタイレーツ",
+            "eng": "Mega Falinks"
           }
         }
       },
@@ -6673,21 +6897,25 @@
           "id": "0652_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガブリガロン",
           "gigantamax": null,
           "type1": "くさ",
           "type2": "かくとう",
           "hp": 88,
-          "attack": 107,
-          "defense": 122,
+          "attack": 137,
+          "defense": 172,
           "special_attack": 74,
-          "special_defense": 75,
-          "speed": 64,
+          "special_defense": 115,
+          "speed": 44,
           "ability1": "",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>体当<rp>(</rp><rt>たいあ</rt><rp>)</rp></ruby>たりで ５０トンの <ruby>戦車<rp>(</rp><rt>せんしゃ</rt><rp>)</rp></ruby>を ひっくり<ruby>返<rp>(</rp><rt>かえ</rt><rp>)</rp></ruby>す パワー。<ruby>自分<rp>(</rp><rt>じぶん</rt><rp>)</rp></ruby>が <ruby>盾<rp>(</rp><rt>たて</rt><rp>)</rp></ruby>となって <ruby>仲間<rp>(</rp><rt>なかま</rt><rp>)</rp></ruby>を <ruby>守<rp>(</rp><rt>まも</rt><rp>)</rp></ruby>る。"
+          },
+          "name": {
+            "jpn": "メガブリガロン",
+            "eng": "Mega Chesnaught"
           }
         }
       },
@@ -6717,21 +6945,25 @@
           "id": "0227_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガエアームド",
           "gigantamax": null,
-          "type1": "ひこう",
-          "type2": "はがね",
+          "type1": "はがね",
+          "type2": "ひこう",
           "hp": 65,
-          "attack": 80,
-          "defense": 140,
+          "attack": 140,
+          "defense": 110,
           "special_attack": 40,
-          "special_defense": 70,
-          "speed": 70,
+          "special_defense": 100,
+          "speed": 110,
           "ability1": "",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "いばらの <ruby>中<rp>(</rp><rt>なか</rt><rp>)</rp></ruby>に <ruby>巣<rp>(</rp><rt>す</rt><rp>)</rp></ruby>を<ruby>作<rp>(</rp><rt>つく</rt><rp>)</rp></ruby>る。トゲで <ruby>傷<rp>(</rp><rt>きず</rt><rp>)</rp></ruby>つきながら <ruby>育<rp>(</rp><rt>そだ</rt><rp>)</rp></ruby>てられた ヒナの <ruby>羽<rp>(</rp><rt>はね</rt><rp>)</rp></ruby>は <ruby>硬<rp>(</rp><rt>かた</rt><rp>)</rp></ruby>くなる。"
+          },
+          "name": {
+            "jpn": "メガエアームド",
+            "eng": "Mega Skarmory"
           }
         }
       },
@@ -6807,21 +7039,25 @@
           "id": "0655_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガマフォクシー",
           "gigantamax": null,
           "type1": "ほのお",
           "type2": "エスパー",
           "hp": 75,
           "attack": 69,
           "defense": 72,
-          "special_attack": 114,
-          "special_defense": 100,
-          "speed": 104,
+          "special_attack": 159,
+          "special_defense": 125,
+          "speed": 134,
           "ability1": "",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>摂氏<rp>(</rp><rt>せっし</rt><rp>)</rp></ruby>３０００<ruby>度<rp>(</rp><rt>ど</rt><rp>)</rp></ruby>の <ruby>炎<rp>(</rp><rt>ほのお</rt><rp>)</rp></ruby>の <ruby>渦<rp>(</rp><rt>うず</rt><rp>)</rp></ruby>を <ruby>超能力<rp>(</rp><rt>ちょうのうりょく</rt><rp>)</rp></ruby>で <ruby>操<rp>(</rp><rt>あやつ</rt><rp>)</rp></ruby>る。<ruby>敵<rp>(</rp><rt>てき</rt><rp>)</rp></ruby>を <ruby>渦<rp>(</rp><rt>うず</rt><rp>)</rp></ruby>で <ruby>包<rp>(</rp><rt>つつ</rt><rp>)</rp></ruby>み <ruby>焼<rp>(</rp><rt>や</rt><rp>)</rp></ruby>きつくす。"
+          },
+          "name": {
+            "jpn": "メガマフォクシー",
+            "eng": "Mega Delphox"
           }
         }
       },
@@ -6897,21 +7133,25 @@
           "id": "0373_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガボーマンダ",
           "gigantamax": null,
-          "type1": "ひこう",
-          "type2": "ドラゴン",
+          "type1": "ドラゴン",
+          "type2": "ひこう",
           "hp": 95,
-          "attack": 135,
-          "defense": 80,
-          "special_attack": 110,
-          "special_defense": 80,
-          "speed": 100,
-          "ability1": "",
+          "attack": 145,
+          "defense": 130,
+          "special_attack": 120,
+          "special_defense": 90,
+          "speed": 120,
+          "ability1": "スカイスキン",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "ひとたび <ruby>怒<rp>(</rp><rt>おこ</rt><rp>)</rp></ruby>ると <ruby>大暴<rp>(</rp><rt>おおあば</rt><rp>)</rp></ruby>れ。<ruby>空<rp>(</rp><rt>そら</rt><rp>)</rp></ruby>を <ruby>飛<rp>(</rp><rt>と</rt><rp>)</rp></ruby>びながら <ruby>地上<rp>(</rp><rt>ちじょう</rt><rp>)</rp></ruby>の <ruby>野山<rp>(</rp><rt>のやま</rt><rp>)</rp></ruby>を <ruby>炎<rp>(</rp><rt>ほのお</rt><rp>)</rp></ruby>で <ruby>焼<rp>(</rp><rt>や</rt><rp>)</rp></ruby>き<ruby>払<rp>(</rp><rt>はら</rt><rp>)</rp></ruby>う。"
+          },
+          "name": {
+            "jpn": "メガボーマンダ",
+            "eng": "Mega Salamence"
           }
         }
       },
@@ -6941,21 +7181,25 @@
           "id": "0115_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガガルーラ",
           "gigantamax": null,
           "type1": "ノーマル",
           "type2": "",
           "hp": 105,
-          "attack": 95,
-          "defense": 80,
-          "special_attack": 40,
-          "special_defense": 80,
-          "speed": 90,
-          "ability1": "",
+          "attack": 125,
+          "defense": 100,
+          "special_attack": 60,
+          "special_defense": 100,
+          "speed": 100,
+          "ability1": "おやこあい",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "お<ruby>腹<rp>(</rp><rt>なか</rt><rp>)</rp></ruby>の <ruby>袋<rp>(</rp><rt>ふくろ</rt><rp>)</rp></ruby>で <ruby>子育<rp>(</rp><rt>こそだ</rt><rp>)</rp></ruby>てをする。<ruby>安全<rp>(</rp><rt>あんぜん</rt><rp>)</rp></ruby>なときだけ <ruby>子供<rp>(</rp><rt>こども</rt><rp>)</rp></ruby>を <ruby>袋<rp>(</rp><rt>ふくろ</rt><rp>)</rp></ruby>から <ruby>出<rp>(</rp><rt>だ</rt><rp>)</rp></ruby>して <ruby>遊<rp>(</rp><rt>あそ</rt><rp>)</rp></ruby>ばせる。"
+          },
+          "name": {
+            "jpn": "メガガルーラ",
+            "eng": "Mega Kangaskhan"
           }
         }
       },
@@ -6985,21 +7229,25 @@
           "id": "0780_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガジジーロン",
           "gigantamax": null,
           "type1": "ノーマル",
           "type2": "ドラゴン",
           "hp": 78,
-          "attack": 60,
-          "defense": 85,
-          "special_attack": 135,
-          "special_defense": 91,
+          "attack": 85,
+          "defense": 110,
+          "special_attack": 160,
+          "special_defense": 116,
           "speed": 36,
           "ability1": "",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "<ruby>心優<rp>(</rp><rt>こころやさ</rt><rp>)</rp></ruby>しい <ruby>性質<rp>(</rp><rt>せいしつ</rt><rp>)</rp></ruby>。だが <ruby>一度<rp>(</rp><rt>いちど</rt><rp>)</rp></ruby> <ruby>怒<rp>(</rp><rt>いか</rt><rp>)</rp></ruby>りに かられると <ruby>激<rp>(</rp><rt>はげ</rt><rp>)</rp></ruby>しい <ruby>息吹<rp>(</rp><rt>いぶき</rt><rp>)</rp></ruby>で あたりを <ruby>破壊<rp>(</rp><rt>はかい</rt><rp>)</rp></ruby> し<ruby>尽<rp>(</rp><rt>つ</rt><rp>)</rp></ruby>くす。"
+          },
+          "name": {
+            "jpn": "メガジジーロン",
+            "eng": "Mega Drampa"
           }
         }
       },
@@ -7075,21 +7323,25 @@
           "id": "0376_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガメタグロス",
           "gigantamax": null,
-          "type1": "エスパー",
-          "type2": "はがね",
+          "type1": "はがね",
+          "type2": "エスパー",
           "hp": 80,
-          "attack": 135,
-          "defense": 130,
-          "special_attack": 95,
-          "special_defense": 90,
-          "speed": 70,
-          "ability1": "",
+          "attack": 145,
+          "defense": 150,
+          "special_attack": 105,
+          "special_defense": 110,
+          "speed": 110,
+          "ability1": "かたいツメ",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "メタングが <ruby>合体<rp>(</rp><rt>がったい</rt><rp>)</rp></ruby>して <ruby>生<rp>(</rp><rt>う</rt><rp>)</rp></ruby>まれた。４つの <ruby>脳<rp>(</rp><rt>のう</rt><rp>)</rp></ruby>を <ruby>持<rp>(</rp><rt>も</rt><rp>)</rp></ruby>つ メタグロスは スーパーコンピュータ<ruby>並<rp>(</rp><rt>な</rt><rp>)</rp></ruby>みの <ruby>知能<rp>(</rp><rt>ちのう</rt><rp>)</rp></ruby>。"
+          },
+          "name": {
+            "jpn": "メガメタグロス",
+            "eng": "Mega Metagross"
           }
         }
       },
@@ -7251,21 +7503,25 @@
           "id": "0719_00000100_0_000_0",
           "form": null,
           "region": null,
-          "mega_evolution": null,
+          "mega_evolution": "メガディアンシー",
           "gigantamax": null,
           "type1": "いわ",
           "type2": "フェアリー",
           "hp": 50,
-          "attack": 100,
-          "defense": 150,
-          "special_attack": 100,
-          "special_defense": 150,
-          "speed": 50,
-          "ability1": "",
+          "attack": 160,
+          "defense": 110,
+          "special_attack": 160,
+          "special_defense": 110,
+          "speed": 110,
+          "ability1": "マジックミラー",
           "ability2": "",
           "dream_ability": "",
           "description": {
             "legendsza": "メレシーの <ruby>突然変異<rp>(</rp><rt>とつぜんへんい</rt><rp>)</rp></ruby>。ピンク<ruby>色<rp>(</rp><rt>いろ</rt><rp>)</rp></ruby>に <ruby>輝<rp>(</rp><rt>かがや</rt><rp>)</rp></ruby>く <ruby>体<rp>(</rp><rt>からだ</rt><rp>)</rp></ruby>は <ruby>世界一<rp>(</rp><rt>せかいいち</rt><rp>)</rp></ruby> <ruby>美<rp>(</rp><rt>うつく</rt><rp>)</rp></ruby>しいと いわれる。"
+          },
+          "name": {
+            "jpn": "メガディアンシー",
+            "eng": "Mega Diancie"
           }
         }
       },


### PR DESCRIPTION
## Summary

Add correct Mega Evolution data for all 64 Mega Pokemon in Legends ZA.

### Problem
The `LegendsZA.json` mega entries had:
- `mega_evolution` field set to `null` (should be the mega name)
- `name` field empty (should have jpn/eng names)
- Stats were copies of base form (not the actual Mega Evolution stats)
- Types were not updated for megas with type changes

### Changes
- Added `mega_evolution` names (jpn/eng) for all 64 Mega Pokemon
- Updated stats to correct Mega Evolution values
- Added correct types for Megas with type changes (e.g., Mega Meganium → Grass/Fairy, Mega Ordile → Water/Dragon)
- Added known abilities where available

### Data Sources
- game8.jp (Pokemon Legends ZA wiki)
- gamewith.jp (Pokemon Legends ZA wiki)
- altema.jp (Pokemon Legends ZA wiki)

### Affected Megas (64 total)
Includes both existing megas (28, with correct ZA stats) and new ZA megas (36):
- New: Mega Dragonite, Mega Meganium, Mega Feraligatr, Mega Starmie, Mega Greninja, Mega Excadrill, Mega Chandelure, Mega Scolipede, Mega Scrafty, Mega Eelektross, Mega Chesnaught, Mega Delphox, Mega Pyroar, Mega Malamar, Mega Barbaracle, Mega Dragalge, Mega Hawlucha, Mega Drampa, Mega Falinks, Mega Clefable, Mega Victreebel, Mega Pinsir, Mega Heracross, Mega Skarmory, Mega Sableye, Mega Medicham, Mega Manectric, Mega Sharpedo, Mega Camerupt, Mega Glalie, Mega Metagross, Mega Lopunny, Mega Gallade, Mega Froslass, Mega Emboar
- Existing (stats updated): Mega Venusaur, Mega Charizard X/Y, Mega Blastoise, Mega Beedrill, Mega Pidgeot, Mega Alakazam, Mega Slowbro, Mega Gengar, Mega Kangaskhan, Mega Gyarados, Mega Aerodactyl, Mega Ampharos, Mega Steelix, Mega Scizor, Mega Houndoom, Mega Tyranitar, Mega Gardevoir, Mega Mawile, Mega Aggron, Mega Altaria, Mega Banette, Mega Absol, Mega Salamence, Mega Garchomp, Mega Lucario, Mega Abomasnow, Mega Audino, Mega Diancie